### PR TITLE
Update stratigility to 2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,11 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Deprecated
 
-- Nothing.
+- [#2](https://github.com/laminas/laminas-mvc-middleware/pull/2) deprecates
+  direct usage of double-pass and callable middleware. Please use the decorators
+  and helper functions provided by laminas-stratigility
+  (`CallableMiddlewareDecorator`, `DoublePassMiddlewareDecorator`,
+  `middleware()`, and `doublePassMiddleware()`).
 
 ### Removed
 

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "laminas/laminas-mvc": "^3.1",
         "laminas/laminas-psr7bridge": "^1.0",
         "laminas/laminas-servicemanager": "^3.3",
-        "laminas/laminas-stratigility": "^2.0 <2.2"
+        "laminas/laminas-stratigility": "^2.2.2p2"
     },
     "require-dev": {
         "container-interop/container-interop": "^1.2",

--- a/docs/book/intro.md
+++ b/docs/book/intro.md
@@ -63,6 +63,15 @@ You may also specify an `array` of above middleware types. These will then be pi
 into a `Laminas\Stratigility\MiddlewarePipe` instance in the order in which they
 are present in the array.
 
+Starting with the 1.1 release, direct usage of double-pass and callable middleware
+is deprecated. laminas-stratigility 2.2 provides the following decorators
+and helper functions that are forwards-compatible with its 3.0 release:
+
+- `Laminas\Stratigility\Middleware\CallableMiddlewareDecorator`
+- `Laminas\Stratigility\Middleware\DoublePassMiddlewareDecorator`
+- `Laminas\Stratigility\doublePassMiddleware()`
+- `Laminas\Stratigility\middleware()`
+
 > ### No action required
 >
 > Unlike action controllers, middleware typically is single purpose, and, as

--- a/test/TestAsset/Middleware.php
+++ b/test/TestAsset/Middleware.php
@@ -8,13 +8,16 @@
 
 namespace LaminasTest\Mvc\Middleware\TestAsset;
 
-use Psr\Http\Message\ResponseInterface;
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Laminas\Diactoros\Response;
 use Psr\Http\Message\ServerRequestInterface;
 
-class Middleware
+class Middleware implements MiddlewareInterface
 {
-    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, $next = null)
+    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
     {
+        $response = new Response();
         $response->getBody()->write(__CLASS__);
         return $response;
     }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
This PR updates stratigility to 2.2.2, updates tests, deprecates direct usage of double-pass and callable middlewares to mirror stratigility forward-compat  changes. No functionality change is brought by this update.