### PR TITLE
PHP 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         }
     },
     "require": {
-        "php": "^7.3",
+        "php": "^7.3 || ~8.0.0",
         "laminas/laminas-mvc": "^3.2",
         "laminas/laminas-psr7bridge": "^1.2.2",
         "laminas/laminas-servicemanager": "^3.4",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,9 +9,9 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <coverage processUncoveredFiles="true">
+        <include>
             <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

adds support for PHP 8

* [x]  Modify `composer.json` to provide support for PHP 8.0 by adding the constraint `~8.0.0`
* [x]  Modify `composer.json` to drop support for PHP less than 7.3
* [x]  Modify `composer.json` to implement phpunit 9.3 which supports PHP 7.3+
* [x]  Modify `.travis.yml` to ignore platform requirements when installing composer dependencies (simply add `--ignore-platform-reqs` to `COMPOSER_ARGS` env variable)
* [x]  Modify `.travis.yml` to add PHP 8.0 to the matrix (_NOTE_: Do not allow failures as PHP 8.0 has a feature freeze since 
* [x]  Modify source code in case there are incompatibilities with PHP 8.0 (there were none)


fixes #5 
