### PR TITLE
Simplify redirects of legacy docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,8 +11,6 @@ nav:
           - Migration from Version 1: v2/migration.md
   - v1:
       - Introduction: v1/intro.md
-  - _hidden-legacy-page-links:
-      - _intro: intro.md
 site_name: laminas-mvc-middleware
 site_description: 'Dispatch middleware pipelines in place of controllers in laminas-mvc.'
 repo_url: 'https://github.com/laminas/laminas-mvc-middleware'
@@ -24,3 +22,8 @@ extra:
   versions:
     - v2
     - v1
+plugins:
+  - search
+  - redirects:
+      redirect_maps:
+        intro.md: v1/intro.md


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

The docs folder contains several manual redirects, i.d. HTML documents with a hard-coded redirect for legacy URLs. With the [adoption of the MkDocs redirect plugin](https://github.com/laminas/documentation-theme/pull/65) there is a simpler solution available.

This PR moves the redirects for legacy URLs in `mkdocs.yml` and removes the manually created HTML documents from Git.