### PR TITLE
Fix broken link in the V2 Quick Start guide in 2.3.x branch

### DIFF
--- a/docs/book/v2/quick-start.md
+++ b/docs/book/v2/quick-start.md
@@ -37,7 +37,7 @@ or `Psr\Http\Server\RequestHandlerInterface`
 or as service name strings resolving to such instances.  
 You may also specify an instance of the `PipeSpec` class which accepts both middleware types above or their service name
 strings, or a `Closure` . These will then be piped into a `Laminas\Stratigility\MiddlewarePipe` instance in the order in
-which they are present in the `PipeSpec`. See [routing middleware](routing-middleware.md) for examples.
+which they are present in the `PipeSpec`. See [dispatching middleware](dispatching-middleware.md) for examples.
 
 > ### No Action Required
 >


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This change fixes a broken link in the V2 Quick Start documentation.
