### PR TITLE
Add maintenance mode notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@
 >
 > You trust us enough to use our software. We ask that you trust us to say the truth on this. We need your help. Go out and protest this unnecessary war. Stop the bloodshed. Say "stop the war!"
 
+> [!CAUTION]
+>
+> ## Maintenance mode
+>
+> This package is considered feature-complete, and is now in **security-only** maintenance mode, following a decision by the Technical Steering Committee.
+> More information on this decision can be found in a blog post: [Laminas MVC End of Life Schedule](https://getlaminas.org/blog/2026-03-06-laminas-mvc-eol-schedule.html).  
+> The security-only status will continue until the security support for PHP 8.4 ends, which will be 31st December 2028.
+>
+> If you have a security issue, please [follow our security reporting guidelines](https://getlaminas.org/security/).
+
 This library provides the ability to dispatch middleware pipelines in place of
 controllers within laminas-mvc.
 


### PR DESCRIPTION
No new version is required for this change, as it will be shown in the Readme file once the changes have been merged.